### PR TITLE
feat(disableAsset): disable asset when the oracle is not up to date

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,15 +1,17 @@
-import { FallbackOracleService } from "./src/fallbackOracle/service";
-import { OracleService } from "./src/oracle/service";
+import { OracleStale } from "./src/application/oracleStale";
+import { FallbackOracleService } from "./src/infra/fallbackOracle/service";
+import { DiaOracleService } from "./src/infra/oracle/diaService";
 import { MINUTES } from "./src/utils/config";
-import { Address, FALLBACK_ADDRESS, ORACLES } from "./src/utils/constants";
-import { signer } from "./src/utils/provider";
+import { Address, ASSETS, FALLBACK_ADDRESS } from "./src/utils/constants";
+import { provider, signer } from "./src/utils/provider";
 
 async function updatePrices() {
   const fallbackOracleService = new FallbackOracleService(FALLBACK_ADDRESS, signer);
-  console.log("assets", ORACLES);
 
-  for (const asset in ORACLES) {
-    const oracleService = new OracleService(ORACLES[asset]);
+  for (const symbol in ASSETS) {
+    const asset = ASSETS[symbol];
+
+    const oracleService = new DiaOracleService(asset.diaOracle, provider);
     const price = await oracleService.getAssetPrice();
   
     console.log(` ${asset} = ${price}`);
@@ -18,9 +20,15 @@ async function updatePrices() {
 }
 
 
+
 function main() {
-  updatePrices();
-  setInterval(updatePrices, Number(MINUTES ?? 1) * 60 * 1000);
+  // updatePrices();
+  // setInterval(updatePrjices, Number(MINUTES ?? 1) * 60 * 1000);
+
+  const oracleStale = new OracleStale();
+
+  oracleStale.checkOracleStale();
+  // setInterval(oracleStale.checkOracleStale, Number(MINUTES ?? 1) * 1000);
 }
 
 main();

--- a/src/application/oracleStale.ts
+++ b/src/application/oracleStale.ts
@@ -1,0 +1,40 @@
+import { RedstoneOracleService } from "../infra/oracle/redStoneService";
+import { PoolConfiguratorService } from "../infra/poolConfigurator/service";
+import { ASSETS, POOL_CONFIGURATOR_ADDRESS, REDSTONE_ORACLE } from "../utils/constants";
+import { provider, signer } from "../utils/provider";
+
+export class OracleStale {
+  readonly STALE_THRESHOLD = 60 * 60; // 1 hour
+  private reservesPaused: Record<keyof typeof ASSETS, boolean>;
+  constructor() {
+    this.reservesPaused = Object.keys(ASSETS).reduce(
+      (acc, key: keyof typeof ASSETS) => ({ ...acc, [key]: false }),
+      {} as Record<keyof typeof ASSETS, boolean>
+    );
+  }
+
+  checkOracleStale = async () => {
+    const poolConfiguratorService = new PoolConfiguratorService(POOL_CONFIGURATOR_ADDRESS, signer);
+  
+    for (const symbol in ASSETS) {
+      const asset = ASSETS[symbol];
+      console.log(`Checking ${symbol}...`);
+      const oracleService = new RedstoneOracleService(REDSTONE_ORACLE, provider);
+      const [latestTimestamp, now] = await oracleService.latestTimestamp();
+      
+      const difference = (BigInt(now) * BigInt(1000)) - latestTimestamp;
+      const stale = difference > this.STALE_THRESHOLD;
+  
+      if (stale && !this.reservesPaused[symbol]) {
+          this.reservesPaused[symbol] = true;
+          await poolConfiguratorService.setReservePause(asset.address, true);
+      } 
+      
+      if (!stale && this.reservesPaused[symbol]) {
+        this.reservesPaused[symbol] = false;
+        await poolConfiguratorService.setReservePause(asset.address, false);
+      }
+    
+    }
+  }  
+}

--- a/src/infra/fallbackOracle/service.ts
+++ b/src/infra/fallbackOracle/service.ts
@@ -1,7 +1,6 @@
-import { ethers } from "ethers";
-import { Address } from "../utils/constants";
-import { BigNumberish } from "ethers";
-import { providerTestnet } from "../utils/provider";
+import { BigNumberish, ethers } from "ethers";
+import { Address } from "../../utils/constants";
+import { providerTestnet } from "../../utils/provider";
 
 
 export class FallbackOracleService {

--- a/src/infra/oracle/diaService.ts
+++ b/src/infra/oracle/diaService.ts
@@ -1,19 +1,20 @@
 import {  ethers } from "ethers";
-import { Address } from "../utils/constants";
-import { provider } from "../utils/provider";
+import { Address } from "../../utils/constants";
 
 
-export class OracleService {
+export class DiaOracleService {
   private address;
+  private provider;
 
-  constructor(oracleAddress: Address) {
+  constructor(oracleAddress: Address, provider: ethers.Provider) {
     this.address = oracleAddress;
+    this.provider = provider;
   }
 
   getAssetPrice = async () => {
     const oracleContract = new ethers.Contract(this.address, [
       "function latestAnswer() external view returns (int256)"
-    ], provider);
+    ], this.provider);
 
     return await oracleContract.latestAnswer();
   }

--- a/src/infra/oracle/redStoneService.ts
+++ b/src/infra/oracle/redStoneService.ts
@@ -1,0 +1,29 @@
+import {  ethers } from "ethers";
+import { Address } from "../../utils/constants";
+
+
+export class RedstoneOracleService {
+  private address;
+  private provider;
+
+  constructor(oracleAddress: Address, provider: ethers.Provider) {
+    this.address = oracleAddress;
+    this.provider = provider;
+  }
+
+  priceOf = async (asset: Address) => {
+    const oracleContract = new ethers.Contract(this.address, [
+      "function priceOf(address asset) external view returns (uint256)"
+    ], this.provider);
+
+    return await oracleContract.priceOf(asset);
+  }
+
+  latestTimestamp = async () => {
+    const oracleContract = new ethers.Contract(this.address, [
+      "function getTimestampsFromLatestUpdate() external view returns (uint128, uint128)"
+    ], this.provider);
+
+    return await oracleContract.getTimestampsFromLatestUpdate();
+  }
+}

--- a/src/infra/poolConfigurator/service.ts
+++ b/src/infra/poolConfigurator/service.ts
@@ -1,0 +1,19 @@
+import { ethers } from "ethers";
+import { Address } from "../../utils/constants";
+
+export class PoolConfiguratorService {
+  private poolConfiguratorAddress: Address;
+  private signer: ethers.Signer;
+  constructor(poolConfiguratorAddress: Address, signer: ethers.Signer) {
+    this.poolConfiguratorAddress = poolConfiguratorAddress;
+    this.signer = signer;
+  }
+
+  setReservePause = async (asset: Address, paused: boolean) => {
+    const oracleContract = new ethers.Contract(this.poolConfiguratorAddress, [
+      "function setReservePause(address asset, bool paused) external"
+    ], this.signer);
+
+    return await oracleContract.setReservePause(asset, paused);
+  }
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -5,3 +5,4 @@ export const RPC_URL_TESTNET = process.env.RPC_URL_TESTNET;
 export const IS_TESTNET = process.env.IS_TESTNET;
 export const PRIVATE_KEY = process.env.PRIVATE_KEY;
 export const MINUTES = process.env.MINUTES;
+export const STALE_THRESHOLD = process.env.STALE_THRESHOLD;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,15 +1,23 @@
 export type Address = `0x${string}`;
 
-export const ASSET_ADDRESSES= {
-  USDC: '0x14E986C4a733B555c317D95Fe0FC5bFB5a7D166C' as Address,
-  DAI: '0xcb913C75362A7Fd39de6A5DDE4341F370F5B4419' as Address,
-  WETH: '0x8CEc2719a2e896A11eA3f10406EfDb6Ad87281D9' as Address,
+export const ASSETS= {
+  USDC: {
+    address: '0x14E986C4a733B555c317D95Fe0FC5bFB5a7D166C' as Address,
+    diaOracle: '0x13B6052B34c6A9Fe0419E5154826a1CB858f3181' as Address,
+    productionAddess: '0x05D032ac25d322df992303dCa074EE7392C117b9' as Address
+  },
+  DAI: {
+    address: '0xcb913C75362A7Fd39de6A5DDE4341F370F5B4419' as Address,
+    diaOracle: '0xF67Ce8007810e8e87B3871B104366b105a71bB55' as Address,
+    productionAddess: '0x05D032ac25d322df992303dCa074EE7392C117b9' as Address
+  },
+  WETH: {
+    address: '0x8CEc2719a2e896A11eA3f10406EfDb6Ad87281D9' as Address,
+    diaOracle: '0x27abC874f709fbc7b2af4153e875cf52C701725E' as Address,
+    productionAddess: '0x05D032ac25d322df992303dCa074EE7392C117b9' as Address
+  }
 } as const;
 
-export const ORACLES: Record<Address, Address> = {
-  [ASSET_ADDRESSES.USDC]: '0x13B6052B34c6A9Fe0419E5154826a1CB858f3181' as Address,
-  [ASSET_ADDRESSES.DAI]: '0xF67Ce8007810e8e87B3871B104366b105a71bB55' as Address,
-  [ASSET_ADDRESSES.WETH]: '0x27abC874f709fbc7b2af4153e875cf52C701725E' as Address,
-} as const satisfies Record<Address, Address>;
-
+export const REDSTONE_ORACLE = '0x2d484E029b8Ae5cA6335DAe11fC726B232bE87D1' as Address;
 export const FALLBACK_ADDRESS = '0x49Fd3dbdd6D984523dEbE445853371AFd403aA66' as Address;
+export const POOL_CONFIGURATOR_ADDRESS = '0xe73d349DAE57D1884C96d97654181E3527ea5B7C' as Address;


### PR DESCRIPTION
# Concept proof

This script periodically checks whether the oracle (Redstone interface) is in a stale state. The check runs in a loop with a defined time interval. If the last oracle update exceeds a predefined threshold (set as a constant), the asset will be disabled, preventing any further actions on it such as supply, borrow, repayment, and others.

